### PR TITLE
Bug fix, add if-then-else in formulas, and conversions from BDD to formulas

### DIFF
--- a/lib/bdd.ml
+++ b/lib/bdd.ml
@@ -461,9 +461,11 @@ let rec extract_known_values cache b =
          let m1 = extract_known_values cache l in
          let m2 = extract_known_values cache h in
          let merge_bool _ b1 b2 =
-           if b1=b2 then Some b1 else None
+           match b1, b2 with
+           | Some b1, Some b2 when b1=b2 -> Some b1
+           | _ -> None
          in
-         BddVarMap.union merge_bool m1 m2
+         BddVarMap.merge merge_bool m1 m2
     in
     H1.add cache b res;
     res

--- a/lib/bdd.mli
+++ b/lib/bdd.mli
@@ -31,6 +31,7 @@ type formula =
   | Fimp of formula * formula
   | Fiff of formula * formula
   | Fnot of formula
+  | Fite of formula * formula * formula (* if f1 then f2 else f3 *)
 
 module type BDD = sig
   (** Binary Decision Diagrams (BDDs) *)
@@ -135,6 +136,17 @@ module type BDD = sig
         Raises [Invalid_argument] if [f] contains a variable out of
         [1..max_var]. *)
 
+  val as_formula : t -> formula
+  (** Builds a propositional formula from the given BDD. The returned
+     formula is only build using if-then-else ([Fite]) and variables
+     ([Fvar]).  *)
+
+  val as_compact_formula : t -> formula
+  (** Builds a ``compact'' formula from the given BDD. The returned
+     formula is only build using conjunctions, disjunctions,
+     variables, negations of variables, and if-then-else where the if
+     condition is a variable.  *)
+
   (** Satisfiability *)
 
   val is_sat : t -> bool
@@ -142,6 +154,13 @@ module type BDD = sig
 
   val tautology : t -> bool
     (** Checks if a bdd is a tautology i.e. equal to [one] *)
+
+  val equivalent : t -> t -> bool
+    (** Checks if a bdd is equivalent to another bdd *)
+
+  val entails : t -> t -> bool
+    (** [entails b1 b2] checks that [b1] entails [b2], in other words
+        [b1] implies [b2] *)
 
   val count_sat_int : t -> int
   val count_sat : t -> Int64.t


### PR DESCRIPTION
The bug fix is indeed a soundness bug in [extract_known_values]

The addition of `if-then-else` in formulas allows to provide conversion from a BDD back to a formula, in two ways: a naive one using only if-then-else on variables, and a more compact one which tries to reconstructs conjunctions, disjunctions, negations, whenever possible (which makes use of [extract_known_values]).