### PR TITLE
Fix opam installation & Updated Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Many executables:
 - `queen`: computes the number of solutions to the n-queens problem, using a propositional formula (this is not an efficient way to solve this problem, simply another way to test the `bdd` library)
 - `path`
 - `check`: a quick check
-- `bench_prop_cli`: generate valide propositional formulae from command line
+- `bench_prop_cli`: generate valid propositional formulae from command line
 
 To run any of them, let's say `check`, do:
 
@@ -39,8 +39,10 @@ dune exec test/check.exe
 You can combine some of them, e.g.:
 
 ```sh
-dune exec test/bench_prop_cli -pigeon-p 7 | dune exec test/bdd_sat.exe
+dune exec test/bench_prop_cli.exe -- -pigeon-p 7 | dune exec test/bdd_sat.exe
 ```
+
+You might need to set the environment variable `DUNE_CONFIG__GLOBAL_LOCK` to `disabled` to allow multiple dune instance running.
 
 ## Test
 

--- a/bdd.opam
+++ b/bdd.opam
@@ -2,17 +2,19 @@ opam-version: "2.0"
 synopsis: "Implementation of BDD"
 maintainer: "Jean-Christophe.Filliatre@lri.fr"
 authors: "Jean-Christophe Filliâtre"
-license: "LGPL-2.1"
+license: "LGPL-2.1-only"
 homepage: "https://www.lri.fr/~filliatr/software.en.html"
 bug-reports: "https://github.com/backtracking/ocaml-bdd/issues"
 depends: [
   "dune" {build}
   "stdlib-shims"
+  "menhir"
+  "odoc" {with-doc}
 ]
 build: [
   ["dune" "subst"] {pinned}
   ["dune" "build" "@install" "-p" name "-j" jobs]
-  [with-doc "dune" "build" "@doc" "-p" name]
-  [with-test "dune" "runtest" "-p" name]
+  ["dune" "build" "@doc" "-p" name] {with-doc}
+  ["dune" "runtest" "-p" name] {with-test}
 ]
 dev-repo: "git://github.com/backtracking/ocaml-bdd.git"

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,3 @@
 (lang dune 1.6)
 (using menhir 2.0)
+(name bdd)


### PR DESCRIPTION
We use this library in a course given by @tbrk. However, the version available on opam is quite old and has an obsolete api.

This PR aims to correct the problems that arise when this library is installed locally by opam (via `opam install .` after cloning this repository).

A typo and an addition on test execution with dune have also been added to the README.

Would it be possible to update the opam version of this library as well?

Thanks in advance!